### PR TITLE
add initial MainDocumentArea, add initial utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "lorem-ipsum": "^2.0.8",
     "lucide-react": "^0.513.0",
     "next": "15.3.3",
     "prop-types": "^15.8.1",

--- a/src/app/document-search/components/Dashboard.js
+++ b/src/app/document-search/components/Dashboard.js
@@ -3,12 +3,15 @@
 import { MOCK_REGEX_VALUES } from "../mock-data"
 import MainDocumentArea from "./MainDocumentArea"
 import Sidebar from "./Sidebar"
+import { getInitialDocumentText } from "./utils"
+
 
 const Dashboard = ({ regexData = MOCK_REGEX_VALUES }) => {
+    const initialText = getInitialDocumentText()
   return (
     <div>
       <Sidebar regexData={regexData}/>
-      <MainDocumentArea />
+      <MainDocumentArea initialText={initialText} />
     </div>
   )
 }

--- a/src/app/document-search/components/MainDocumentArea.js
+++ b/src/app/document-search/components/MainDocumentArea.js
@@ -1,11 +1,32 @@
 "use client"
 
-const MainDocumentArea = () => {
+import PropTypes from "prop-types"
+
+const MainDocumentArea = ({ initialText, matches }) => {
+  const renderTextMatchSection = () => {
+    return (
+      <div className="my-4 w-full">
+        {matches ? (
+          <p>
+            Results from search: <span>{matches.toString()}</span>
+          </p>
+        ) : (
+          <p>No matches found.</p>
+        )}
+      </div>
+    )
+  }
   return (
-    <div>
-      <textarea />
+    <div className="w-full">
+      <textarea className="w-full h-80" defaultValue={initialText} />
+      {renderTextMatchSection()}
     </div>
   )
 }
 
 export default MainDocumentArea
+
+MainDocumentArea.propTypes = {
+  initialText: PropTypes.string.isRequired,
+  matches: PropTypes.array
+}

--- a/src/app/document-search/components/utils.js
+++ b/src/app/document-search/components/utils.js
@@ -1,0 +1,5 @@
+import { loremIpsum } from "lorem-ipsum"
+
+export const getInitialDocumentText = () => {
+  return loremIpsum({ count: 20 })
+}


### PR DESCRIPTION
Add initial MainDocumentArea, rendering lorem-ipsum text via the lorem-ipsum package.

## Changes
- add initial values and styling for MainDocumentArea
- add lorem-ipsum package
- add initial utils file
## Features missing
- Hoist changes made by user to Dashboard
- Matches Section rendering actual data