### PR TITLE
Feature/add regex search results

### DIFF
--- a/src/app/document-search/components/ApproveSection.js
+++ b/src/app/document-search/components/ApproveSection.js
@@ -11,11 +11,17 @@ import {
 import PropTypes from "prop-types"
 import { useState } from "react"
 
-const ApproveSection = ({ options }) => {
+const ApproveSection = ({ options, handleSelection }) => {
   const [selectedRegex, setSelectedRegex] = useState(null)
+
+    const handleOptionSelect = (value) => {
+        handleSelection(value)
+        setSelectedRegex(value)
+    }
+
   const renderDropdown = () => {
     return (
-      <Select onValueChange={(option) => setSelectedRegex(option)}>
+      <Select onValueChange={(option) => handleOptionSelect(option)}>
         <SelectTrigger>
           <SelectValue placeholder="Select Regex" />
         </SelectTrigger>

--- a/src/app/document-search/components/Dashboard.js
+++ b/src/app/document-search/components/Dashboard.js
@@ -1,17 +1,28 @@
 "use client"
 
+import { useState } from "react"
 import { MOCK_REGEX_VALUES } from "../mock-data"
 import MainDocumentArea from "./MainDocumentArea"
 import Sidebar from "./Sidebar"
-import { getInitialDocumentText } from "./utils"
+import { getRegexResults } from "./utils"
 
+const Dashboard = ({ regexData = MOCK_REGEX_VALUES, initialText }) => {
+  const [document, setDocument] = useState(initialText)
+  const [results, setResults] = useState(
+    getRegexResults(regexData, initialText)
+  )
+  const handleSidebarModeSelection = (regex) => {
+    const results = getRegexResults(regex, document)
+    setResults(results)
+  }
 
-const Dashboard = ({ regexData = MOCK_REGEX_VALUES }) => {
-    const initialText = getInitialDocumentText()
   return (
     <div className="flex">
-      <Sidebar regexData={regexData}/>
-      <MainDocumentArea initialText={initialText} />
+      <Sidebar
+        regexData={regexData}
+        handleModeChange={(regex) => handleSidebarModeSelection(regex)}
+      />
+      <MainDocumentArea initialText={initialText} matches={results} />
     </div>
   )
 }

--- a/src/app/document-search/components/EditRegexSection.js
+++ b/src/app/document-search/components/EditRegexSection.js
@@ -2,7 +2,11 @@ import { Button } from "@/components/ui/button"
 import PropTypes from "prop-types"
 import { useState } from "react"
 
-const EditRegexSection = ({ options, handleEdit, handleDelete }) => {
+const EditRegexSection = ({
+  options,
+  handleEdit,
+  handleDelete
+}) => {
   const [isEditing, setIsEditing] = useState(null)
   const [newRegexValue, setNewRegexValue] = useState("")
 
@@ -26,10 +30,13 @@ const EditRegexSection = ({ options, handleEdit, handleDelete }) => {
       <div className="items-center my-2 max-w-[80%]">
         <p>Editing {value}</p>
         <input
+          className="max-w-[120px] my-2"
           defaultValue={value}
           onChange={(e) => setNewRegexValue(e.target.value)}
         />
-        <Button onClick={() => handleSaveClick()}>Save</Button>
+        <Button className="my-2" onClick={() => handleSaveClick()}>
+          Save
+        </Button>
         <Button onClick={() => handleDeleteClick()}>Delete</Button>
       </div>
     )
@@ -65,7 +72,7 @@ const EditRegexSection = ({ options, handleEdit, handleDelete }) => {
     })
   }
   return (
-    <div className="flex flex-col items-center m-4 max-w-[80%]">
+    <div className="flex flex-col items-center text-center m-4 max-w-[150px]">
       <p>Expressions</p>
       {renderData()}
       {renderAddButton()}

--- a/src/app/document-search/components/Sidebar.js
+++ b/src/app/document-search/components/Sidebar.js
@@ -6,22 +6,24 @@ import ApproveSection from "./ApproveSection"
 import EditRegexSection from "./EditRegexSection"
 import PropTypes from "prop-types"
 
-const Sidebar = ({ regexData }) => {
+const Sidebar = ({ regexData, handleModeChange }) => {
   const [shouldShowApprovalSection, setShouldShowApprovalSection] =
     useState(false)
   return (
     <aside className="w-64 mr-6 rounded min-h-full bg-gray-300 block top-0 left-0 ">
       <div className="mt-2 flex place-self-center">
         <Button
-          onClick={() =>
+          onClick={() => {
             setShouldShowApprovalSection(!shouldShowApprovalSection)
+            handleModeChange(regexData)
+        }
           }
         >
           Switch Mode
         </Button>
       </div>
       {shouldShowApprovalSection ? (
-        <ApproveSection options={regexData} />
+        <ApproveSection options={regexData} handleSelection={(selectedRegex) => handleModeChange(selectedRegex)} />
       ) : (
         <EditRegexSection options={regexData}/>
       )}

--- a/src/app/document-search/components/utils.js
+++ b/src/app/document-search/components/utils.js
@@ -3,3 +3,13 @@ import { loremIpsum } from "lorem-ipsum"
 export const getInitialDocumentText = () => {
   return loremIpsum({ count: 20 })
 }
+
+export function getRegexTextSearchResults(input, text) {
+    try {
+      const regex = new RegExp(input, "g")
+      const results = text.match(regex)
+      return results
+    } catch (e) {
+      console.log("Error: ", e)
+    }
+}

--- a/src/app/document-search/components/utils.js
+++ b/src/app/document-search/components/utils.js
@@ -4,12 +4,22 @@ export const getInitialDocumentText = () => {
   return loremIpsum({ count: 20 })
 }
 
-export function getRegexTextSearchResults(input, text) {
-    try {
-      const regex = new RegExp(input, "g")
-      const results = text.match(regex)
-      return results
-    } catch (e) {
-      console.log("Error: ", e)
-    }
+export function searchTextWithRegex(input, text) {
+  try {
+    const regex = new RegExp(input, "g")
+    const results = text.match(regex)
+    return results
+  } catch (e) {
+    console.log("Error: ", e)
+  }
+}
+
+export function getRegexResults(input, text) {
+  if (Array.isArray(input)) {
+    return input.map((regex) => {
+      return searchTextWithRegex(regex.value, text)
+    })
+  } else {
+    return searchTextWithRegex(input, text)
+  }
 }

--- a/src/app/document-search/mock-data.js
+++ b/src/app/document-search/mock-data.js
@@ -1,8 +1,8 @@
 export const MOCK_REGEX_VALUES = [
     {
-        value: '/[A-Z]/', status: 'pending'
+        value: '[A-Z]', status: 'pending'
     },
     {
-        value: '/lorem/', status: 'approved'
+        value: 'do', status: 'approved'
     },
 ]

--- a/src/app/document-search/page.js
+++ b/src/app/document-search/page.js
@@ -1,10 +1,12 @@
 import Dashboard from "./components/Dashboard"
+import { getInitialDocumentText } from "./components/utils"
 
 export default function DocumentSearchPage() {
+    const initialText = getInitialDocumentText()
   return (
     <>
       <div>Hello World!</div>
-      <Dashboard />
+      <Dashboard initialText={initialText} />
     </>
   )
 }


### PR DESCRIPTION
## Overview
This MR adds the ability to view regex results, both in array and single string form
## Changes
- fix page re-render for generated text
- add helper to retrieve results of regex search through given text
- add results display to MainDocumentArea
- add ability for both single regex and multiple regex results to display
- fix styling on EditRegexSection to respect width
## Technical Details
- Text was unfortunately re-rendering on page load, as it was being called by a client component (`Dashboard`) that was rehydrating and thus, calling `getInitialDocumentText()` a second time
- This has now been fixed by moving the call to the base Page RSC, as it should only generate once.
- Initially was using a helper function to get all regex matches that only accepted an array to initially set the `results` state for Dashboard
- After dealing with re-rendering issues when switching between 'modes' in ` Sidebar`,  refactored said helper function to determine if the regex passed in is an array or a single expression, then calls the actual search.
- This is re-run on both mode select to `EditRegexSection` and when a single expression is selected in `ApproveSection`